### PR TITLE
Update ad_status_lamp_manager following autoware_state_machine removal

### DIFF
--- a/include/ad_status_lamp_manager/ad_status_lamp_manager.hpp
+++ b/include/ad_status_lamp_manager/ad_status_lamp_manager.hpp
@@ -83,7 +83,9 @@ public:
   int blink_type_;
   bool active_polarity_;
   uint16_t service_layer_state_;
+  uint16_t pre_service_layer_state_;
   uint16_t control_layer_state_;
+  uint16_t pre_control_layer_state_;
   uint16_t initilization_state_;
   uint16_t routing_state_;
   SoundDoneTuple_t sound_param_;

--- a/include/ad_status_lamp_manager/ad_status_lamp_manager.hpp
+++ b/include/ad_status_lamp_manager/ad_status_lamp_manager.hpp
@@ -17,7 +17,14 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "autoware_state_machine_msgs/msg/state_machine.hpp"
+#include "autoware_state_machine_msgs/msg/state_sound_done.hpp"
 #include "dio_ros_driver/msg/dio_port.hpp"
+#include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
+#include <autoware_adapi_v1_msgs/msg/route_state.hpp>
+#include <autoware_adapi_v1_msgs/msg/diag_graph_status.hpp>
+#include <autoware_adapi_v1_msgs/msg/diag_graph_struct.hpp>
+#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
 
 namespace ad_status_lamp_manager
 {
@@ -38,6 +45,12 @@ public:
 
   // Subscriber
   rclcpp::Subscription<autoware_state_machine_msgs::msg::StateMachine>::SharedPtr sub_state_;
+  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::LocalizationInitializationState>::SharedPtr sub_initilization_state_;
+  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::RouteState>::SharedPtr sub_routing_state_;
+  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateSoundDone>::SharedPtr sub_sound_state_;
+  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::DiagGraphStatus>::SharedPtr sub_daignostics_status_;
+  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::DiagGraphStruct>::SharedPtr sub_daignostics_struct_;
+  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::OperationModeState>::SharedPtr sub_operation_mode_state_;
 
   #define BLINK_FAST_ON_DURATION (0.2)
   #define BLINK_FAST_OFF_DURATION (0.2)
@@ -58,19 +71,46 @@ public:
     BLINK_SLOW_ON_DURATION
   };
 
+  typedef struct tuple
+  {
+    uint16_t state;
+    bool done;
+  } SoundDoneTuple_t;
+
   rclcpp::TimerBase::SharedPtr blink_timer_;
+  rclcpp::TimerBase::SharedPtr init_timer_;
   uint64_t blink_sequence_;
   int blink_type_;
   bool active_polarity_;
+  uint16_t service_layer_state_;
+  uint16_t control_layer_state_;
+  uint16_t initilization_state_;
+  uint16_t routing_state_;
+  SoundDoneTuple_t sound_param_;
+  std::optional<uint16_t> em_holding_indices_;
+  bool em_holding_;
+  autoware_adapi_v1_msgs::msg::OperationModeState operation_state_;
 
-  void callbackStateMessage(
-    const autoware_state_machine_msgs::msg::StateMachine::ConstSharedPtr msg);
   void publishLampState(const bool value);
   void lampManager(const uint16_t service_layer_state, const uint8_t control_layer_state);
   void startLampBlinkOperation(int blink_type);
   void lampBlinkOperationCallback(void);
   double getTimerDuration(void);
   void setPeriod(const double new_period);
+  void callbackAutowareInitializationMessage(
+    const autoware_adapi_v1_msgs::msg::LocalizationInitializationState::ConstSharedPtr msg);
+  void callbackRoutingStateMessage(
+    const autoware_adapi_v1_msgs::msg::RouteState::ConstSharedPtr msg);
+  void callbackSoundDoneMessage(
+    const autoware_state_machine_msgs::msg::StateSoundDone::ConstSharedPtr msg_ptr);
+  void callbackDaignosticsStructMessage(
+    const autoware_adapi_v1_msgs::msg::DiagGraphStruct::ConstSharedPtr msg);
+  void callbackDaignosticsStateMessage(
+    const autoware_adapi_v1_msgs::msg::DiagGraphStatus::ConstSharedPtr msg);
+  void callbackOperationModeStateMessage(
+    const autoware_adapi_v1_msgs::msg::OperationModeState::ConstSharedPtr msg);
+  void changeState(void);
+  void initOnTimer(void);
 };
 
 }  // namespace ad_status_lamp_manager

--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,8 @@
   <depend>dio_ros_driver</depend>
   <depend>autoware_state_machine_msgs</depend>
   <depend>rclcpp_components</depend>
+  <depend>autoware_adapi_v1_msgs</depend>
+  <depend>diagnostic_msgs</depend>
 
   <depend>builtin_interfaces</depend>
 

--- a/src/ad_status_lamp_manager.cpp
+++ b/src/ad_status_lamp_manager.cpp
@@ -76,7 +76,9 @@ AdStatusLampManager::AdStatusLampManager(const rclcpp::NodeOptions & options = r
   active_polarity_ = ACTIVE_POLARITY;
   em_holding_indices_ = std::nullopt;
   service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED;
+  pre_service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED;
   control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::MANUAL;
+  pre_control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::MANUAL;
   initilization_state_ = autoware_adapi_v1_msgs::msg::LocalizationInitializationState::UNKNOWN;
   routing_state_ = autoware_adapi_v1_msgs::msg::RouteState::UNKNOWN;
   sound_param_.state = autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED;
@@ -236,6 +238,11 @@ void AdStatusLampManager::publishLampState(const bool value)
 void AdStatusLampManager::lampManager(
   const uint16_t service_layer_state, const uint8_t control_layer_state)
 {
+  if (pre_service_layer_state_ == service_layer_state &&
+      pre_control_layer_state_ == control_layer_state) {
+    return;
+  }
+
   switch (service_layer_state) {
     case autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_WAKEUP:
     case autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_CLOSE:
@@ -266,6 +273,9 @@ void AdStatusLampManager::lampManager(
       }
       break;
   }
+
+  pre_service_layer_state_ = service_layer_state;
+  pre_control_layer_state_ = control_layer_state;
 }
 
 double AdStatusLampManager::getTimerDuration(void)

--- a/src/ad_status_lamp_manager.cpp
+++ b/src/ad_status_lamp_manager.cpp
@@ -23,29 +23,93 @@ namespace ad_status_lamp_manager
 AdStatusLampManager::AdStatusLampManager(const rclcpp::NodeOptions & options = rclcpp::NodeOptions())
 : Node("ad_status_lamp_manager", options)
 {
-  sub_state_ = this->create_subscription<autoware_state_machine_msgs::msg::StateMachine>(
-    "autoware_state_machine/state",
+  // subscriber
+  // autoware_state
+  sub_initilization_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::LocalizationInitializationState>(
+    "/api/localization/initialization_state",
     rclcpp::QoS{3}.transient_local(),
-    std::bind(&AdStatusLampManager::callbackStateMessage, this, std::placeholders::_1)
+    std::bind(&AdStatusLampManager::callbackAutowareInitializationMessage, this, std::placeholders::_1)
   );
+
+  // routing wait state
+  sub_routing_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::RouteState>(
+    "/api/routing/state",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&AdStatusLampManager::callbackRoutingStateMessage, this, std::placeholders::_1)
+  );
+
+  // ad_sound_manager sound done state
+  sub_sound_state_ = this->create_subscription<autoware_state_machine_msgs::msg::StateSoundDone>(
+    "/autoware_state_machine/state_sound_done",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&AdStatusLampManager::callbackSoundDoneMessage, this, std::placeholders::_1)
+  );
+
+  // daignostics struct for EM Holding
+  sub_daignostics_struct_ = this->create_subscription<autoware_adapi_v1_msgs::msg::DiagGraphStruct>(
+    "/api/system/diagnostics/struct",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&AdStatusLampManager::callbackDaignosticsStructMessage, this, std::placeholders::_1)
+  );
+
+  // daignostics status for EM Holding
+  sub_daignostics_status_ = this->create_subscription<autoware_adapi_v1_msgs::msg::DiagGraphStatus>(
+    "/api/system/diagnostics/status",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&AdStatusLampManager::callbackDaignosticsStateMessage, this, std::placeholders::_1)
+  );
+
+  // OperationModeState
+  sub_operation_mode_state_ = this->create_subscription<autoware_adapi_v1_msgs::msg::OperationModeState>(
+    "/api/operation_mode/state",
+    rclcpp::QoS{3}.transient_local(),
+    std::bind(&AdStatusLampManager::callbackOperationModeStateMessage, this, std::placeholders::_1)
+  );
+
+  // publisher
+  // lamp state
   pub_ad_status_lamp_ = this->create_publisher<dio_ros_driver::msg::DIOPort>(
     "ad_status_lamp_out",
     rclcpp::QoS{3}.transient_local());
 
+  // Set Initial Value
   active_polarity_ = ACTIVE_POLARITY;
+  em_holding_indices_ = std::nullopt;
+  service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED;
+  control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::MANUAL;
+  initilization_state_ = autoware_adapi_v1_msgs::msg::LocalizationInitializationState::UNKNOWN;
+  routing_state_ = autoware_adapi_v1_msgs::msg::RouteState::UNKNOWN;
+  sound_param_.state = autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED;
+  sound_param_.done = false;
+  em_holding_ = false;
+  operation_state_.is_autoware_control_enabled = false;
+  operation_state_.is_in_transition = false;
+  operation_state_.is_stop_mode_available = false;
+  operation_state_.is_autonomous_mode_available = false;
+  operation_state_.is_local_mode_available = false;
+  operation_state_.is_remote_mode_available = false;
 
   // Timer
+  // Lamp on/off
   std::chrono::milliseconds timer_period_msec;
   timer_period_msec = std::chrono::duration_cast<std::chrono::milliseconds>(
     std::chrono::duration<double>(1.0));
 
-  auto timer_callback = std::bind(&AdStatusLampManager::lampBlinkOperationCallback, this);
+    auto timer_callback = std::bind(&AdStatusLampManager::lampBlinkOperationCallback, this);
   blink_timer_ = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
     this->get_clock(), timer_period_msec, std::move(timer_callback),
     this->get_node_base_interface()->get_context()
   );
   this->get_node_timers_interface()->add_timer(blink_timer_, nullptr);
   blink_timer_->cancel();
+
+  // initailize state
+  auto init_timer_callback = std::bind(&AdStatusLampManager::initOnTimer, this);
+  init_timer_ = std::make_shared<rclcpp::GenericTimer<decltype(init_timer_callback)>>(
+    this->get_clock(), timer_period_msec, std::move(init_timer_callback),
+    this->get_node_base_interface()->get_context()
+  );
+  this->get_node_timers_interface()->add_timer(init_timer_, nullptr);
 
   publishLampState(false);
 }
@@ -56,17 +120,109 @@ AdStatusLampManager::~AdStatusLampManager()
   blink_timer_->cancel();
 }
 
-void AdStatusLampManager::callbackStateMessage(
-  const autoware_state_machine_msgs::msg::StateMachine::ConstSharedPtr msg)
+void AdStatusLampManager::callbackAutowareInitializationMessage(
+  const autoware_adapi_v1_msgs::msg::LocalizationInitializationState::ConstSharedPtr msg)
 {
   RCLCPP_INFO_THROTTLE(
     this->get_logger(),
     *this->get_clock(), 1.0,
-    "[AdStatusLampManager::callbackStateMessage]service_layer_state: %u, control_layer_state: %u",
-    msg->service_layer_state,
-    msg->control_layer_state);
+    "[AdStatusLampManager::callbackAutowareInitializationMessage]autoware_state: %u",
+    msg->state);
 
-  lampManager(msg->service_layer_state, msg->control_layer_state);
+  initilization_state_ = msg->state;
+
+  changeState();
+  lampManager(service_layer_state_, control_layer_state_);
+}
+
+void AdStatusLampManager::callbackRoutingStateMessage(
+  const autoware_adapi_v1_msgs::msg::RouteState::ConstSharedPtr msg)
+{
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(), 1.0,
+    "[AdStatusLampManager::callbackRoutingStateMessage]routing_state: %u",
+    msg->state);
+
+  routing_state_ = msg->state;
+
+  changeState();
+  lampManager(service_layer_state_, control_layer_state_);
+}
+
+void AdStatusLampManager::callbackSoundDoneMessage(
+  const autoware_state_machine_msgs::msg::StateSoundDone::ConstSharedPtr msg_ptr)
+{
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(), 1.0,
+    "[AdStatusLampManager::callbackSoundDoneMessage]Sound Done %d, %d ",
+      msg_ptr->state, msg_ptr->done);
+
+  sound_param_.state = msg_ptr->state;
+  sound_param_.done = msg_ptr->done;
+
+  changeState();
+  lampManager(service_layer_state_, control_layer_state_);
+}
+
+void AdStatusLampManager::callbackDaignosticsStructMessage(
+  const autoware_adapi_v1_msgs::msg::DiagGraphStruct::ConstSharedPtr msg)
+{
+  auto nodes = msg->nodes;
+
+  for (uint16_t i = 0; i < nodes.size(); ++i) {
+    if (nodes[i].path == "/autoware/modes/autonomous") {
+      em_holding_indices_ = i;
+      RCLCPP_INFO_THROTTLE(
+        this->get_logger(),
+        *this->get_clock(), 1.0,
+        "[AdStatusLampManager::callbackDaignosticsStructMessage]daignostics_graph /autoware/modes/autonomous index: %u", i);
+      break;
+    }
+  }
+}
+
+void AdStatusLampManager::callbackDaignosticsStateMessage(
+  const autoware_adapi_v1_msgs::msg::DiagGraphStatus::ConstSharedPtr msg)
+{
+  auto nodes = msg->nodes;
+  if (em_holding_indices_ != std::nullopt) {
+    if (nodes[em_holding_indices_.value()].latch_level == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
+      em_holding_ = true;
+      RCLCPP_INFO_THROTTLE(
+        this->get_logger(),
+        *this->get_clock(), 1.0,
+        "[AdStatusLampManager::callbackDaignosticsStateMessage]/autoware/modes/autonomous latch_level: %u",
+        nodes[em_holding_indices_.value()].latch_level);
+    } else {
+      em_holding_ = false;
+    }
+
+    changeState();
+    lampManager(service_layer_state_, control_layer_state_);
+  }
+}
+
+void AdStatusLampManager::callbackOperationModeStateMessage(
+  const autoware_adapi_v1_msgs::msg::OperationModeState::ConstSharedPtr msg)
+{
+  operation_state_ = *msg;
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(), 1.0,
+    "[AdStatusLampManager::callbackOperationModeStateMessage]operation mode: %u",
+      msg->mode);
+
+  changeState();
+  lampManager(service_layer_state_, control_layer_state_);
+}
+
+void AdStatusLampManager::initOnTimer(void)
+{
+  init_timer_->cancel();
+  changeState();
+  lampManager(service_layer_state_, control_layer_state_);
 }
 
 void AdStatusLampManager::publishLampState(const bool value)
@@ -171,6 +327,38 @@ void AdStatusLampManager::setPeriod(const double new_period)
   blink_timer_->reset();
 }
 
+void AdStatusLampManager::changeState(void)
+{
+  if ((service_layer_state_ == autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED)){
+    // STATE_CHECK_NODE_ALIVE
+    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_CHECK_NODE_ALIVE;
+  } else if (em_holding_ == true) {
+    // STATE_EMERGENCY_STOP
+    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_EMERGENCY_STOP;
+  } else if ((routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::UNSET) ||
+             (routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::CHANGING) ||
+             (routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::ARRIVED)) {
+    // STATE_DURING_RECEIVE_ROUTE
+    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_RECEIVE_ROUTE;
+  } else if ((initilization_state_ == autoware_adapi_v1_msgs::msg::LocalizationInitializationState::INITIALIZING)
+          && (((operation_state_.is_stop_mode_available == true)
+            || (operation_state_.is_local_mode_available == true))
+            || ((sound_param_.state == autoware_state_machine_msgs::msg::StateMachine::STATE_CHECK_NODE_ALIVE)
+              && (sound_param_.done == true)))) {
+    // STATE_DURING_WAKEUP
+    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_WAKEUP;
+  } else {
+    // 上記以外
+    service_layer_state_ = 0xFFFF;
+  }
+
+  if ((operation_state_.is_stop_mode_available == true) ||
+      (operation_state_.is_local_mode_available == true)) {
+    control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::MANUAL;
+  } else {
+    control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::AUTO;
+  }
+}
 }  // namespace ad_status_lamp_manager
 
 #include "rclcpp_components/register_node_macro.hpp"

--- a/src/ad_status_lamp_manager.cpp
+++ b/src/ad_status_lamp_manager.cpp
@@ -188,13 +188,14 @@ void AdStatusLampManager::callbackDaignosticsStateMessage(
 {
   auto nodes = msg->nodes;
   if (em_holding_indices_ != std::nullopt) {
-    if (nodes[em_holding_indices_.value()].latch_level == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
+    // TODO:Ph3にて、levelをlatch_levelに変更
+    if (nodes[em_holding_indices_.value()].level == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
       em_holding_ = true;
       RCLCPP_INFO_THROTTLE(
         this->get_logger(),
         *this->get_clock(), 1.0,
         "[AdStatusLampManager::callbackDaignosticsStateMessage]/autoware/modes/autonomous latch_level: %u",
-        nodes[em_holding_indices_.value()].latch_level);
+        nodes[em_holding_indices_.value()].level);// TODO:Ph3にて、levelをlatch_levelに変更
     } else {
       em_holding_ = false;
     }


### PR DESCRIPTION
ad_status_lamp_manager内で使用していた状態に応じて、autoware_state_machine相当の状態遷移を内部に実装
- autoware_state_machineのservice_stateは、以下の5つ
  - STATE_CHECK_NODE_ALIVE
  - STATE_DURING_WAKEUP
  - STATE_DURING_CLOSE
  - STATE_DURING_RECEIVE_ROUTE
  - STATE_EMERGENCY_STOP
- autoware_state_machineのcontrol_stateは、以下の1つ
  - MANUAL

