### PR TITLE
feat : add unit tests and delete autoware_state_machine_msgs depend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,17 @@ rclcpp_components_register_node(ad_status_lamp_manager
   PLUGIN "ad_status_lamp_manager::AdStatusLampManager"
   EXECUTABLE ad_status_lamp_manager_node)
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_ros_isolated_gtest(test_ad_status_lamp_manager
+    test/test_ad_status_lamp_manager.cpp
+  )
+  target_link_libraries(test_ad_status_lamp_manager
+    ad_status_lamp_manager
+  )
+endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/include/ad_status_lamp_manager/ad_status_lamp_manager.hpp
+++ b/include/ad_status_lamp_manager/ad_status_lamp_manager.hpp
@@ -15,19 +15,39 @@
 #ifndef AD_STATUS_LAMP_MANAGER__AD_STATUS_LAMP_MANAGER_HPP_
 #define AD_STATUS_LAMP_MANAGER__AD_STATUS_LAMP_MANAGER_HPP_
 
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
 #include "rclcpp/rclcpp.hpp"
-#include "autoware_state_machine_msgs/msg/state_machine.hpp"
-#include "autoware_state_machine_msgs/msg/state_sound_done.hpp"
 #include "dio_ros_driver/msg/dio_port.hpp"
 #include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/route_state.hpp>
-#include <autoware_adapi_v1_msgs/msg/diag_graph_status.hpp>
-#include <autoware_adapi_v1_msgs/msg/diag_graph_struct.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
 
 namespace ad_status_lamp_manager
 {
+
+// Local constants to replace autoware_state_machine_msgs::msg::StateMachine
+namespace ServiceLayerState
+{
+  constexpr uint16_t STATE_UNDEFINED = 0;
+  constexpr uint16_t STATE_DURING_WAKEUP = 1;
+  constexpr uint16_t STATE_DURING_CLOSE = 2;
+  constexpr uint16_t STATE_CHECK_NODE_ALIVE = 3;
+  constexpr uint16_t STATE_DURING_RECEIVE_ROUTE = 4;
+  constexpr uint16_t STATE_EMERGENCY_STOP = 5;
+  constexpr uint16_t STATE_OTHER = 0xFFFF;
+}  // namespace ServiceLayerState
+
+namespace ControlLayerState
+{
+  constexpr uint8_t MANUAL = 0;
+  constexpr uint8_t AUTO = 1;
+}  // namespace ControlLayerState
+
 class AdStatusLampManager : public rclcpp::Node
 {
 public:
@@ -40,17 +60,22 @@ public:
     BLINK_SLOW
   };
 
+  // 状態遷移条件の型定義
+  using StateCondition = std::function<bool()>;
+  struct StateTransition
+  {
+    StateCondition condition;
+    uint16_t state;
+  };
+
   // Publisher
   rclcpp::Publisher<dio_ros_driver::msg::DIOPort>::SharedPtr pub_ad_status_lamp_;
 
   // Subscriber
-  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateMachine>::SharedPtr sub_state_;
   rclcpp::Subscription<autoware_adapi_v1_msgs::msg::LocalizationInitializationState>::SharedPtr sub_initilization_state_;
   rclcpp::Subscription<autoware_adapi_v1_msgs::msg::RouteState>::SharedPtr sub_routing_state_;
-  rclcpp::Subscription<autoware_state_machine_msgs::msg::StateSoundDone>::SharedPtr sub_sound_state_;
-  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::DiagGraphStatus>::SharedPtr sub_daignostics_status_;
-  rclcpp::Subscription<autoware_adapi_v1_msgs::msg::DiagGraphStruct>::SharedPtr sub_daignostics_struct_;
   rclcpp::Subscription<autoware_adapi_v1_msgs::msg::OperationModeState>::SharedPtr sub_operation_mode_state_;
+  rclcpp::Subscription<autoware_system_msgs::msg::HazardStatusStamped>::SharedPtr sub_hazard_status_;
 
   #define BLINK_FAST_ON_DURATION (0.2)
   #define BLINK_FAST_OFF_DURATION (0.2)
@@ -71,12 +96,6 @@ public:
     BLINK_SLOW_ON_DURATION
   };
 
-  typedef struct tuple
-  {
-    uint16_t state;
-    bool done;
-  } SoundDoneTuple_t;
-
   rclcpp::TimerBase::SharedPtr blink_timer_;
   rclcpp::TimerBase::SharedPtr init_timer_;
   uint64_t blink_sequence_;
@@ -88,10 +107,11 @@ public:
   uint16_t pre_control_layer_state_;
   uint16_t initilization_state_;
   uint16_t routing_state_;
-  SoundDoneTuple_t sound_param_;
-  std::optional<uint16_t> em_holding_indices_;
   bool em_holding_;
   autoware_adapi_v1_msgs::msg::OperationModeState operation_state_;
+
+  // 状態遷移テーブル（優先順位順）
+  std::vector<StateTransition> state_transitions_;
 
   void publishLampState(const bool value);
   void lampManager(const uint16_t service_layer_state, const uint8_t control_layer_state);
@@ -103,16 +123,14 @@ public:
     const autoware_adapi_v1_msgs::msg::LocalizationInitializationState::ConstSharedPtr msg);
   void callbackRoutingStateMessage(
     const autoware_adapi_v1_msgs::msg::RouteState::ConstSharedPtr msg);
-  void callbackSoundDoneMessage(
-    const autoware_state_machine_msgs::msg::StateSoundDone::ConstSharedPtr msg_ptr);
-  void callbackDaignosticsStructMessage(
-    const autoware_adapi_v1_msgs::msg::DiagGraphStruct::ConstSharedPtr msg);
-  void callbackDaignosticsStateMessage(
-    const autoware_adapi_v1_msgs::msg::DiagGraphStatus::ConstSharedPtr msg);
   void callbackOperationModeStateMessage(
     const autoware_adapi_v1_msgs::msg::OperationModeState::ConstSharedPtr msg);
+  void callbackHazardStatusMessage(
+    const autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
   void changeState(void);
   void initOnTimer(void);
+  static std::string getServiceLayerStateName(uint16_t state);
+  static std::string getControlLayerStateName(uint16_t state);
 };
 
 }  // namespace ad_status_lamp_manager

--- a/package.xml
+++ b/package.xml
@@ -28,12 +28,14 @@
 
   <depend>rclcpp</depend>
   <depend>dio_ros_driver</depend>
-  <depend>autoware_state_machine_msgs</depend>
   <depend>rclcpp_components</depend>
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>diagnostic_msgs</depend>
+  <depend>autoware_system_msgs</depend>
 
   <depend>builtin_interfaces</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_ros</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/ad_status_lamp_manager.cpp
+++ b/src/ad_status_lamp_manager.cpp
@@ -38,25 +38,11 @@ AdStatusLampManager::AdStatusLampManager(const rclcpp::NodeOptions & options = r
     std::bind(&AdStatusLampManager::callbackRoutingStateMessage, this, std::placeholders::_1)
   );
 
-  // ad_sound_manager sound done state
-  sub_sound_state_ = this->create_subscription<autoware_state_machine_msgs::msg::StateSoundDone>(
-    "/autoware_state_machine/state_sound_done",
+  // HazardStatus for EM Holding
+  sub_hazard_status_ = this->create_subscription<autoware_system_msgs::msg::HazardStatusStamped>(
+    "/system/emergency/hazard_status",
     rclcpp::QoS{3}.transient_local(),
-    std::bind(&AdStatusLampManager::callbackSoundDoneMessage, this, std::placeholders::_1)
-  );
-
-  // daignostics struct for EM Holding
-  sub_daignostics_struct_ = this->create_subscription<autoware_adapi_v1_msgs::msg::DiagGraphStruct>(
-    "/api/system/diagnostics/struct",
-    rclcpp::QoS{3}.transient_local(),
-    std::bind(&AdStatusLampManager::callbackDaignosticsStructMessage, this, std::placeholders::_1)
-  );
-
-  // daignostics status for EM Holding
-  sub_daignostics_status_ = this->create_subscription<autoware_adapi_v1_msgs::msg::DiagGraphStatus>(
-    "/api/system/diagnostics/status",
-    rclcpp::QoS{3}.transient_local(),
-    std::bind(&AdStatusLampManager::callbackDaignosticsStateMessage, this, std::placeholders::_1)
+    std::bind(&AdStatusLampManager::callbackHazardStatusMessage, this, std::placeholders::_1)
   );
 
   // OperationModeState
@@ -74,15 +60,12 @@ AdStatusLampManager::AdStatusLampManager(const rclcpp::NodeOptions & options = r
 
   // Set Initial Value
   active_polarity_ = ACTIVE_POLARITY;
-  em_holding_indices_ = std::nullopt;
-  service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED;
-  pre_service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED;
-  control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::MANUAL;
-  pre_control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::MANUAL;
+  service_layer_state_ = ServiceLayerState::STATE_UNDEFINED;
+  pre_service_layer_state_ = ServiceLayerState::STATE_UNDEFINED;
+  control_layer_state_ = ControlLayerState::MANUAL;
+  pre_control_layer_state_ = ControlLayerState::MANUAL;
   initilization_state_ = autoware_adapi_v1_msgs::msg::LocalizationInitializationState::UNKNOWN;
   routing_state_ = autoware_adapi_v1_msgs::msg::RouteState::UNKNOWN;
-  sound_param_.state = autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED;
-  sound_param_.done = false;
   em_holding_ = false;
   operation_state_.is_autoware_control_enabled = false;
   operation_state_.is_in_transition = false;
@@ -90,6 +73,33 @@ AdStatusLampManager::AdStatusLampManager(const rclcpp::NodeOptions & options = r
   operation_state_.is_autonomous_mode_available = false;
   operation_state_.is_local_mode_available = false;
   operation_state_.is_remote_mode_available = false;
+
+  // 状態遷移テーブルの初期化（優先順位順に評価される）
+  state_transitions_ = {
+    {
+      [this]() { return service_layer_state_ == ServiceLayerState::STATE_UNDEFINED; },
+      ServiceLayerState::STATE_CHECK_NODE_ALIVE
+    },
+    {
+      [this]() { return em_holding_; },
+      ServiceLayerState::STATE_EMERGENCY_STOP
+    },
+    {
+      [this]() {
+        return routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::UNSET ||
+               routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::CHANGING ||
+               routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::ARRIVED;
+      },
+      ServiceLayerState::STATE_DURING_RECEIVE_ROUTE
+    },
+    {
+      [this]() {
+        return initilization_state_ == autoware_adapi_v1_msgs::msg::LocalizationInitializationState::INITIALIZING &&
+               (operation_state_.is_stop_mode_available || operation_state_.is_local_mode_available);
+      },
+      ServiceLayerState::STATE_DURING_WAKEUP
+    }
+  };
 
   // Timer
   // Lamp on/off
@@ -152,59 +162,18 @@ void AdStatusLampManager::callbackRoutingStateMessage(
   lampManager(service_layer_state_, control_layer_state_);
 }
 
-void AdStatusLampManager::callbackSoundDoneMessage(
-  const autoware_state_machine_msgs::msg::StateSoundDone::ConstSharedPtr msg_ptr)
+void AdStatusLampManager::callbackHazardStatusMessage(
+  const autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg)
 {
+  em_holding_ = msg->status.emergency_holding;
   RCLCPP_INFO_THROTTLE(
     this->get_logger(),
     *this->get_clock(), 1.0,
-    "[AdStatusLampManager::callbackSoundDoneMessage]Sound Done %d, %d ",
-      msg_ptr->state, msg_ptr->done);
-
-  sound_param_.state = msg_ptr->state;
-  sound_param_.done = msg_ptr->done;
+    "[AdStatusLampManager::callbackHazardStatusMessage]emergency_holding: %s",
+    em_holding_ ? "true" : "false");
 
   changeState();
   lampManager(service_layer_state_, control_layer_state_);
-}
-
-void AdStatusLampManager::callbackDaignosticsStructMessage(
-  const autoware_adapi_v1_msgs::msg::DiagGraphStruct::ConstSharedPtr msg)
-{
-  auto nodes = msg->nodes;
-
-  for (uint16_t i = 0; i < nodes.size(); ++i) {
-    if (nodes[i].path == "/autoware/modes/autonomous") {
-      em_holding_indices_ = i;
-      RCLCPP_INFO_THROTTLE(
-        this->get_logger(),
-        *this->get_clock(), 1.0,
-        "[AdStatusLampManager::callbackDaignosticsStructMessage]daignostics_graph /autoware/modes/autonomous index: %u", i);
-      break;
-    }
-  }
-}
-
-void AdStatusLampManager::callbackDaignosticsStateMessage(
-  const autoware_adapi_v1_msgs::msg::DiagGraphStatus::ConstSharedPtr msg)
-{
-  auto nodes = msg->nodes;
-  if (em_holding_indices_ != std::nullopt) {
-    // TODO:Ph3にて、levelをlatch_levelに変更
-    if (nodes[em_holding_indices_.value()].level == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
-      em_holding_ = true;
-      RCLCPP_INFO_THROTTLE(
-        this->get_logger(),
-        *this->get_clock(), 1.0,
-        "[AdStatusLampManager::callbackDaignosticsStateMessage]/autoware/modes/autonomous latch_level: %u",
-        nodes[em_holding_indices_.value()].level);// TODO:Ph3にて、levelをlatch_levelに変更
-    } else {
-      em_holding_ = false;
-    }
-
-    changeState();
-    lampManager(service_layer_state_, control_layer_state_);
-  }
 }
 
 void AdStatusLampManager::callbackOperationModeStateMessage(
@@ -244,26 +213,26 @@ void AdStatusLampManager::lampManager(
   }
 
   switch (service_layer_state) {
-    case autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_WAKEUP:
-    case autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_CLOSE:
-    case autoware_state_machine_msgs::msg::StateMachine::STATE_CHECK_NODE_ALIVE:
+    case ServiceLayerState::STATE_DURING_WAKEUP:
+    case ServiceLayerState::STATE_DURING_CLOSE:
+    case ServiceLayerState::STATE_CHECK_NODE_ALIVE:
       // slow blink
       startLampBlinkOperation(BLINK_SLOW);
       break;
 
-    case autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_RECEIVE_ROUTE:
+    case ServiceLayerState::STATE_DURING_RECEIVE_ROUTE:
       // fast blink
       startLampBlinkOperation(BLINK_FAST);
       break;
 
-    case autoware_state_machine_msgs::msg::StateMachine::STATE_EMERGENCY_STOP:
+    case ServiceLayerState::STATE_EMERGENCY_STOP:
       // lamp on
       blink_timer_->cancel();
       publishLampState(true);
       break;
 
     default:
-      if (control_layer_state == autoware_state_machine_msgs::msg::StateMachine::MANUAL) {
+      if (control_layer_state == ControlLayerState::MANUAL) {
         // fast blink
         startLampBlinkOperation(BLINK_FAST);
       } else {
@@ -340,34 +309,61 @@ void AdStatusLampManager::setPeriod(const double new_period)
 
 void AdStatusLampManager::changeState(void)
 {
-  if ((service_layer_state_ == autoware_state_machine_msgs::msg::StateMachine::STATE_UNDEFINED)){
-    // STATE_CHECK_NODE_ALIVE
-    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_CHECK_NODE_ALIVE;
-  } else if (em_holding_ == true) {
-    // STATE_EMERGENCY_STOP
-    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_EMERGENCY_STOP;
-  } else if ((routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::UNSET) ||
-             (routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::CHANGING) ||
-             (routing_state_ == autoware_adapi_v1_msgs::msg::RouteState::ARRIVED)) {
-    // STATE_DURING_RECEIVE_ROUTE
-    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_RECEIVE_ROUTE;
-  } else if ((initilization_state_ == autoware_adapi_v1_msgs::msg::LocalizationInitializationState::INITIALIZING)
-          && (((operation_state_.is_stop_mode_available == true)
-            || (operation_state_.is_local_mode_available == true))
-            || ((sound_param_.state == autoware_state_machine_msgs::msg::StateMachine::STATE_CHECK_NODE_ALIVE)
-              && (sound_param_.done == true)))) {
-    // STATE_DURING_WAKEUP
-    service_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::STATE_DURING_WAKEUP;
-  } else {
-    // 上記以外
-    service_layer_state_ = 0xFFFF;
+  // 状態遷移テーブルを順番に評価し、最初にマッチした状態を設定
+  service_layer_state_ = ServiceLayerState::STATE_OTHER;
+  for (const auto & transition : state_transitions_) {
+    if (transition.condition()) {
+      service_layer_state_ = transition.state;
+      break;
+    }
   }
 
-  if ((operation_state_.is_stop_mode_available == true) ||
-      (operation_state_.is_local_mode_available == true)) {
-    control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::MANUAL;
-  } else {
-    control_layer_state_ = autoware_state_machine_msgs::msg::StateMachine::AUTO;
+  // control_layer_state の更新
+  control_layer_state_ = operation_state_.is_autoware_control_enabled
+    ? ControlLayerState::AUTO
+    : ControlLayerState::MANUAL;
+
+  // 状態変化時のログ出力
+  RCLCPP_INFO(
+    this->get_logger(),
+    "[changeState] service_layer_state: %s (%u), control_layer_state: %s (%u)",
+    getServiceLayerStateName(service_layer_state_).c_str(),
+    service_layer_state_,
+    getControlLayerStateName(control_layer_state_).c_str(),
+    control_layer_state_);
+}
+
+std::string AdStatusLampManager::getServiceLayerStateName(uint16_t state)
+{
+  switch (state) {
+    case ServiceLayerState::STATE_UNDEFINED:
+      return "STATE_UNDEFINED";
+    case ServiceLayerState::STATE_DURING_WAKEUP:
+      return "STATE_DURING_WAKEUP";
+    case ServiceLayerState::STATE_DURING_CLOSE:
+      return "STATE_DURING_CLOSE";
+    case ServiceLayerState::STATE_CHECK_NODE_ALIVE:
+      return "STATE_CHECK_NODE_ALIVE";
+    case ServiceLayerState::STATE_DURING_RECEIVE_ROUTE:
+      return "STATE_DURING_RECEIVE_ROUTE";
+    case ServiceLayerState::STATE_EMERGENCY_STOP:
+      return "STATE_EMERGENCY_STOP";
+    case ServiceLayerState::STATE_OTHER:
+      return "STATE_OTHER";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+std::string AdStatusLampManager::getControlLayerStateName(uint16_t state)
+{
+  switch (state) {
+    case ControlLayerState::MANUAL:
+      return "MANUAL";
+    case ControlLayerState::AUTO:
+      return "AUTO";
+    default:
+      return "UNKNOWN";
   }
 }
 }  // namespace ad_status_lamp_manager

--- a/test/test_ad_status_lamp_manager.cpp
+++ b/test/test_ad_status_lamp_manager.cpp
@@ -1,0 +1,302 @@
+// Copyright 2020 eve autonomy inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+#include <gtest/gtest.h>
+
+#include <rclcpp/rclcpp.hpp>
+#include <dio_ros_driver/msg/dio_port.hpp>
+#include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
+#include <autoware_adapi_v1_msgs/msg/route_state.hpp>
+#include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
+
+#include "ad_status_lamp_manager/ad_status_lamp_manager.hpp"
+
+using LocalizationInitializationState = autoware_adapi_v1_msgs::msg::LocalizationInitializationState;
+using RouteState = autoware_adapi_v1_msgs::msg::RouteState;
+using OperationModeState = autoware_adapi_v1_msgs::msg::OperationModeState;
+using HazardStatusStamped = autoware_system_msgs::msg::HazardStatusStamped;
+using DIOPort = dio_ros_driver::msg::DIOPort;
+
+class AdStatusLampManagerTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    node_ = std::make_shared<ad_status_lamp_manager::AdStatusLampManager>(
+      rclcpp::NodeOptions());
+
+    auto qos = rclcpp::QoS(1).reliable().transient_local();
+
+    pub_initialization_state_ = node_->create_publisher<LocalizationInitializationState>(
+      "/api/localization/initialization_state", qos);
+    pub_route_state_ = node_->create_publisher<RouteState>("/api/routing/state", qos);
+    pub_hazard_status_ = node_->create_publisher<HazardStatusStamped>(
+      "/system/emergency/hazard_status", qos);
+    pub_operation_mode_ = node_->create_publisher<OperationModeState>(
+      "/api/operation_mode/state", qos);
+
+    sub_ = node_->create_subscription<DIOPort>(
+      "ad_status_lamp_out", qos,
+      [this](DIOPort::SharedPtr msg) { received_messages_.push_back(*msg); });
+  }
+
+  void TearDown() override { rclcpp::shutdown(); }
+
+  void spinUntilMessage()
+  {
+    auto start_time = std::chrono::steady_clock::now();
+    while (received_messages_.empty() &&
+           std::chrono::steady_clock::now() - start_time < std::chrono::seconds(2)) {
+      rclcpp::spin_some(node_);
+    }
+  }
+
+  void spinSome()
+  {
+    for (int i = 0; i < 5; ++i) {
+      rclcpp::spin_some(node_);
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+  }
+
+  void publishInitializationState(uint16_t state)
+  {
+    LocalizationInitializationState msg;
+    msg.state = state;
+    pub_initialization_state_->publish(msg);
+  }
+
+  void publishRouteState(uint16_t state)
+  {
+    RouteState msg;
+    msg.state = state;
+    pub_route_state_->publish(msg);
+  }
+
+  void publishHazardStatus(bool emergency_holding)
+  {
+    HazardStatusStamped msg;
+    msg.status.emergency_holding = emergency_holding;
+    pub_hazard_status_->publish(msg);
+  }
+
+  void publishOperationMode(bool is_autoware_control, bool is_stop_mode_available,
+                            bool is_local_mode_available)
+  {
+    OperationModeState msg;
+    msg.is_autoware_control_enabled = is_autoware_control;
+    msg.is_stop_mode_available = is_stop_mode_available;
+    msg.is_local_mode_available = is_local_mode_available;
+    pub_operation_mode_->publish(msg);
+  }
+
+  std::shared_ptr<ad_status_lamp_manager::AdStatusLampManager> node_;
+  rclcpp::Publisher<LocalizationInitializationState>::SharedPtr pub_initialization_state_;
+  rclcpp::Publisher<RouteState>::SharedPtr pub_route_state_;
+  rclcpp::Publisher<HazardStatusStamped>::SharedPtr pub_hazard_status_;
+  rclcpp::Publisher<OperationModeState>::SharedPtr pub_operation_mode_;
+  rclcpp::Subscription<DIOPort>::SharedPtr sub_;
+  std::vector<DIOPort> received_messages_;
+};
+
+// Test: getServiceLayerStateName returns correct state names
+TEST_F(AdStatusLampManagerTest, TestGetServiceLayerStateName)
+{
+  using namespace ad_status_lamp_manager;
+
+  EXPECT_EQ(AdStatusLampManager::getServiceLayerStateName(ServiceLayerState::STATE_UNDEFINED),
+            "STATE_UNDEFINED");
+  EXPECT_EQ(AdStatusLampManager::getServiceLayerStateName(ServiceLayerState::STATE_DURING_WAKEUP),
+            "STATE_DURING_WAKEUP");
+  EXPECT_EQ(AdStatusLampManager::getServiceLayerStateName(ServiceLayerState::STATE_DURING_CLOSE),
+            "STATE_DURING_CLOSE");
+  EXPECT_EQ(AdStatusLampManager::getServiceLayerStateName(ServiceLayerState::STATE_CHECK_NODE_ALIVE),
+            "STATE_CHECK_NODE_ALIVE");
+  EXPECT_EQ(AdStatusLampManager::getServiceLayerStateName(ServiceLayerState::STATE_DURING_RECEIVE_ROUTE),
+            "STATE_DURING_RECEIVE_ROUTE");
+  EXPECT_EQ(AdStatusLampManager::getServiceLayerStateName(ServiceLayerState::STATE_EMERGENCY_STOP),
+            "STATE_EMERGENCY_STOP");
+  EXPECT_EQ(AdStatusLampManager::getServiceLayerStateName(ServiceLayerState::STATE_OTHER),
+            "STATE_OTHER");
+  EXPECT_EQ(AdStatusLampManager::getServiceLayerStateName(9999), "UNKNOWN");
+}
+
+// Test: getControlLayerStateName returns correct state names
+TEST_F(AdStatusLampManagerTest, TestGetControlLayerStateName)
+{
+  using namespace ad_status_lamp_manager;
+
+  EXPECT_EQ(AdStatusLampManager::getControlLayerStateName(ControlLayerState::MANUAL), "MANUAL");
+  EXPECT_EQ(AdStatusLampManager::getControlLayerStateName(ControlLayerState::AUTO), "AUTO");
+  EXPECT_EQ(AdStatusLampManager::getControlLayerStateName(99), "UNKNOWN");
+}
+
+// Test: Initial state should be STATE_UNDEFINED
+TEST_F(AdStatusLampManagerTest, TestInitialStateIsUndefined)
+{
+  using namespace ad_status_lamp_manager;
+
+  // Initial state should be STATE_UNDEFINED before any callbacks
+  EXPECT_EQ(node_->service_layer_state_, ServiceLayerState::STATE_UNDEFINED);
+}
+
+// Test: After init timer fires, state should transition from STATE_UNDEFINED
+TEST_F(AdStatusLampManagerTest, TestInitialStateTransitionAfterTimer)
+{
+  using namespace ad_status_lamp_manager;
+
+  // Wait for init timer to fire (1 second timer)
+  auto start_time = std::chrono::steady_clock::now();
+  while (node_->service_layer_state_ == ServiceLayerState::STATE_UNDEFINED &&
+         std::chrono::steady_clock::now() - start_time < std::chrono::seconds(3)) {
+    rclcpp::spin_some(node_);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+
+  // After init timer fires, state should no longer be STATE_UNDEFINED
+  // Note: Without any topic messages, the state transitions to STATE_OTHER
+  // because no conditions in state_transitions_ are met
+  EXPECT_NE(node_->service_layer_state_, ServiceLayerState::STATE_UNDEFINED);
+}
+
+// Test: Emergency holding should trigger STATE_EMERGENCY_STOP
+TEST_F(AdStatusLampManagerTest, TestEmergencyStopState)
+{
+  using namespace ad_status_lamp_manager;
+
+  spinSome();  // Let the node initialize
+
+  publishHazardStatus(true);
+  spinSome();
+
+  EXPECT_EQ(node_->service_layer_state_, ServiceLayerState::STATE_EMERGENCY_STOP);
+}
+
+// Test: Route state UNSET should trigger STATE_DURING_RECEIVE_ROUTE
+TEST_F(AdStatusLampManagerTest, TestRoutingStateUnset)
+{
+  using namespace ad_status_lamp_manager;
+
+  spinSome();
+
+  publishRouteState(RouteState::UNSET);
+  spinSome();
+
+  EXPECT_EQ(node_->service_layer_state_, ServiceLayerState::STATE_DURING_RECEIVE_ROUTE);
+}
+
+// Test: Route state CHANGING should trigger STATE_DURING_RECEIVE_ROUTE
+TEST_F(AdStatusLampManagerTest, TestRoutingStateChanging)
+{
+  using namespace ad_status_lamp_manager;
+
+  spinSome();
+
+  publishRouteState(RouteState::CHANGING);
+  spinSome();
+
+  EXPECT_EQ(node_->service_layer_state_, ServiceLayerState::STATE_DURING_RECEIVE_ROUTE);
+}
+
+// Test: Route state ARRIVED should trigger STATE_DURING_RECEIVE_ROUTE
+TEST_F(AdStatusLampManagerTest, TestRoutingStateArrived)
+{
+  using namespace ad_status_lamp_manager;
+
+  spinSome();
+
+  publishRouteState(RouteState::ARRIVED);
+  spinSome();
+
+  EXPECT_EQ(node_->service_layer_state_, ServiceLayerState::STATE_DURING_RECEIVE_ROUTE);
+}
+
+// Test: Initialization state INITIALIZING with stop_mode_available should trigger STATE_DURING_WAKEUP
+TEST_F(AdStatusLampManagerTest, TestDuringWakeupState)
+{
+  using namespace ad_status_lamp_manager;
+
+  spinSome();
+
+  // Set routing state to SET (not UNSET/CHANGING/ARRIVED)
+  publishRouteState(RouteState::SET);
+  spinSome();
+
+  // Set operation mode with stop_mode_available = true
+  publishOperationMode(false, true, false);
+  spinSome();
+
+  // Set initialization state to INITIALIZING
+  publishInitializationState(LocalizationInitializationState::INITIALIZING);
+  spinSome();
+
+  EXPECT_EQ(node_->service_layer_state_, ServiceLayerState::STATE_DURING_WAKEUP);
+}
+
+// Test: Control layer state changes based on is_autoware_control_enabled
+TEST_F(AdStatusLampManagerTest, TestControlLayerStateManual)
+{
+  using namespace ad_status_lamp_manager;
+
+  spinSome();
+
+  // is_autoware_control_enabled = false -> MANUAL
+  publishOperationMode(false, false, false);
+  spinSome();
+
+  EXPECT_EQ(node_->control_layer_state_, ControlLayerState::MANUAL);
+}
+
+// Test: Control layer state AUTO when is_autoware_control_enabled = true
+TEST_F(AdStatusLampManagerTest, TestControlLayerStateAuto)
+{
+  using namespace ad_status_lamp_manager;
+
+  spinSome();
+
+  publishOperationMode(true, false, false);
+  spinSome();
+
+  EXPECT_EQ(node_->control_layer_state_, ControlLayerState::AUTO);
+}
+
+// Test: Emergency stop has higher priority than routing state
+TEST_F(AdStatusLampManagerTest, TestEmergencyStopPriority)
+{
+  using namespace ad_status_lamp_manager;
+
+  spinSome();
+
+  // Set routing state to UNSET
+  publishRouteState(RouteState::UNSET);
+  spinSome();
+
+  // Emergency holding should take priority
+  publishHazardStatus(true);
+  spinSome();
+
+  EXPECT_EQ(node_->service_layer_state_, ServiceLayerState::STATE_EMERGENCY_STOP);
+}
+
+// Test: Lamp output is published
+TEST_F(AdStatusLampManagerTest, TestLampOutputPublished)
+{
+  received_messages_.clear();
+
+  spinUntilMessage();
+
+  ASSERT_FALSE(received_messages_.empty());
+}


### PR DESCRIPTION
# description
This pull request simplify its dependencies. The main changes include removing legacy message types and diagnostic handling, switching to a more maintainable state transition table, and updating emergency holding logic to use `HazardStatus`. Additionally, test infrastructure and dependencies are improved for easier validation.

# test
I checked

1. colcon test passed
2. warning_lamp and emergency_lamp status true/false of each states in Planning simulator.
