### PR TITLE
fix: fix sub_hazard_status_ qos

### DIFF
--- a/src/ad_status_lamp_manager.cpp
+++ b/src/ad_status_lamp_manager.cpp
@@ -41,7 +41,7 @@ AdStatusLampManager::AdStatusLampManager(const rclcpp::NodeOptions & options = r
   // HazardStatus for EM Holding
   sub_hazard_status_ = this->create_subscription<autoware_system_msgs::msg::HazardStatusStamped>(
     "/system/emergency/hazard_status",
-    rclcpp::QoS{3}.transient_local(),
+    rclcpp::QoS{1},
     std::bind(&AdStatusLampManager::callbackHazardStatusMessage, this, std::placeholders::_1)
   );
 

--- a/test/test_ad_status_lamp_manager.cpp
+++ b/test/test_ad_status_lamp_manager.cpp
@@ -44,7 +44,7 @@ protected:
       "/api/localization/initialization_state", qos);
     pub_route_state_ = node_->create_publisher<RouteState>("/api/routing/state", qos);
     pub_hazard_status_ = node_->create_publisher<HazardStatusStamped>(
-      "/system/emergency/hazard_status", qos);
+      "/system/emergency/hazard_status", rclcpp::QoS(1));
     pub_operation_mode_ = node_->create_publisher<OperationModeState>(
       "/api/operation_mode/state", qos);
 


### PR DESCRIPTION
# description
This pull request simplify its dependencies. The main changes include removing legacy message types and diagnostic handling, switching to a more maintainable state transition table, and updating emergency holding logic to use HazardStatus. Additionally, test infrastructure and dependencies are improved for easier validation.

# test
I checked

colcon test passed
warning_lamp and emergency_lamp status true/false of each states in Planning simulator.