### PR TITLE
refactor: replace autoware_system_msgs with tier4_external_api_msgs

### DIFF
--- a/include/ad_status_lamp_manager/ad_status_lamp_manager.hpp
+++ b/include/ad_status_lamp_manager/ad_status_lamp_manager.hpp
@@ -25,7 +25,7 @@
 #include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/route_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
+#include <tier4_external_api_msgs/msg/hazard_status_stamped.hpp>
 
 namespace ad_status_lamp_manager
 {
@@ -75,7 +75,7 @@ public:
   rclcpp::Subscription<autoware_adapi_v1_msgs::msg::LocalizationInitializationState>::SharedPtr sub_initilization_state_;
   rclcpp::Subscription<autoware_adapi_v1_msgs::msg::RouteState>::SharedPtr sub_routing_state_;
   rclcpp::Subscription<autoware_adapi_v1_msgs::msg::OperationModeState>::SharedPtr sub_operation_mode_state_;
-  rclcpp::Subscription<autoware_system_msgs::msg::HazardStatusStamped>::SharedPtr sub_hazard_status_;
+  rclcpp::Subscription<tier4_external_api_msgs::msg::HazardStatusStamped>::SharedPtr sub_hazard_status_;
 
   #define BLINK_FAST_ON_DURATION (0.2)
   #define BLINK_FAST_OFF_DURATION (0.2)
@@ -126,7 +126,7 @@ public:
   void callbackOperationModeStateMessage(
     const autoware_adapi_v1_msgs::msg::OperationModeState::ConstSharedPtr msg);
   void callbackHazardStatusMessage(
-    const autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
+    const tier4_external_api_msgs::msg::HazardStatusStamped::ConstSharedPtr msg);
   void changeState(void);
   void initOnTimer(void);
   static std::string getServiceLayerStateName(uint16_t state);

--- a/package.xml
+++ b/package.xml
@@ -30,7 +30,7 @@
   <depend>dio_ros_driver</depend>
   <depend>rclcpp_components</depend>
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_system_msgs</depend>
+  <depend>tier4_external_api_msgs</depend>
 
   <depend>builtin_interfaces</depend>
 

--- a/src/ad_status_lamp_manager.cpp
+++ b/src/ad_status_lamp_manager.cpp
@@ -38,9 +38,9 @@ AdStatusLampManager::AdStatusLampManager(const rclcpp::NodeOptions & options = r
     std::bind(&AdStatusLampManager::callbackRoutingStateMessage, this, std::placeholders::_1)
   );
 
-  // HazardStatus for EM Holding
-  sub_hazard_status_ = this->create_subscription<autoware_system_msgs::msg::HazardStatusStamped>(
-    "/system/emergency/hazard_status",
+  // HazardStatus for EM Holding (/api/external/get/hazard_status)
+  sub_hazard_status_ = this->create_subscription<tier4_external_api_msgs::msg::HazardStatusStamped>(
+    "/api/external/get/hazard_status",
     rclcpp::QoS{1},
     std::bind(&AdStatusLampManager::callbackHazardStatusMessage, this, std::placeholders::_1)
   );
@@ -151,7 +151,7 @@ void AdStatusLampManager::callbackRoutingStateMessage(
 }
 
 void AdStatusLampManager::callbackHazardStatusMessage(
-  const autoware_system_msgs::msg::HazardStatusStamped::ConstSharedPtr msg)
+  const tier4_external_api_msgs::msg::HazardStatusStamped::ConstSharedPtr msg)
 {
   em_holding_ = msg->status.emergency_holding;
 

--- a/test/test_ad_status_lamp_manager.cpp
+++ b/test/test_ad_status_lamp_manager.cpp
@@ -19,14 +19,14 @@
 #include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/route_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
+#include <tier4_external_api_msgs/msg/hazard_status_stamped.hpp>
 
 #include "ad_status_lamp_manager/ad_status_lamp_manager.hpp"
 
 using LocalizationInitializationState = autoware_adapi_v1_msgs::msg::LocalizationInitializationState;
 using RouteState = autoware_adapi_v1_msgs::msg::RouteState;
 using OperationModeState = autoware_adapi_v1_msgs::msg::OperationModeState;
-using HazardStatusStamped = autoware_system_msgs::msg::HazardStatusStamped;
+using HazardStatusStamped = tier4_external_api_msgs::msg::HazardStatusStamped;
 using DIOPort = dio_ros_driver::msg::DIOPort;
 
 class AdStatusLampManagerTest : public ::testing::Test
@@ -44,7 +44,7 @@ protected:
       "/api/localization/initialization_state", qos);
     pub_route_state_ = node_->create_publisher<RouteState>("/api/routing/state", qos);
     pub_hazard_status_ = node_->create_publisher<HazardStatusStamped>(
-      "/system/emergency/hazard_status", rclcpp::QoS(1));
+      "/api/external/get/hazard_status", rclcpp::QoS(1));
     pub_operation_mode_ = node_->create_publisher<OperationModeState>(
       "/api/operation_mode/state", qos);
 


### PR DESCRIPTION
# description
Migrate the `emergency_holding` topic from `/system/emergency/hazard_status` to `/api/external/get/hazard_status`.

# test
Psim launcher and rviz plugin set emergency 30seconds,`/api/external/get/hazard_status`'s emergency_holding field is true.

`ros2 topic echo /dio/dout0`
and
when /api/external/get/hazard_status's emergency_holding field is true,
`/dio/dout0` value kept false.

# remark
` /dio/dout0 `value keep false, when autonoumous driving. 